### PR TITLE
Use `view.view_proj` for world projection

### DIFF
--- a/src/render/lighting/lighting.wgsl
+++ b/src/render/lighting/lighting.wgsl
@@ -65,7 +65,7 @@ fn fragment(vo: FullscreenVertexOutput) -> @location(0) vec4<f32> {
         // it to screen space in order to do things like compute distances (let
         // alone render it in the correct place).
         let point_light_screen_center =
-            world_to_screen(point_light.center, view.viewport.zw, view.projection);
+            world_to_screen(point_light.center, view.viewport.zw, view.view_proj);
 
         // Compute the distance between the current position and the light's center.
         // We multiply by the scale factor as otherwise our distance will always be


### PR DESCRIPTION
Hi there! I was checking this out and seeing how it could fit into my project when I found a small issue with the world->screen projection not respecting the camera transform.

I'm not 100% on top of bevy rendering logic but from referencing bevy's sprite shaders seems like using `view.view_proj` instead of `view.projection` includes the camera's transform as well the "camera projection".

## Summary
- Use `view.view_proj` instead of `view.projection` for `world_to_screen()`