### PR TITLE
Add HDR support

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -8,7 +8,8 @@ use bevy::{
         extract_component::UniformComponentPlugin,
         gpu_component_array_buffer::GpuComponentArrayBufferPlugin,
         render_graph::{RenderGraphApp, ViewNodeRunner},
-        RenderApp,
+        render_resource::SpecializedRenderPipelines,
+        Render, RenderApp, RenderSet,
     },
 };
 
@@ -19,7 +20,10 @@ use crate::{
             extract_ambient_lights, extract_point_lights, ExtractedAmbientLight2d,
             ExtractedPointLight2d,
         },
-        lighting::{LightingNode, LightingPass, LightingPipeline, LIGHTING_SHADER},
+        lighting::{
+            prepare_lighting_pipelines, LightingNode, LightingPass, LightingPipeline,
+            LIGHTING_SHADER,
+        },
     },
 };
 
@@ -47,9 +51,14 @@ impl Plugin for Light2dPlugin {
         };
 
         render_app
+            .init_resource::<SpecializedRenderPipelines<LightingPipeline>>()
             .add_systems(
                 ExtractSchedule,
                 (extract_point_lights, extract_ambient_lights),
+            )
+            .add_systems(
+                Render,
+                prepare_lighting_pipelines.in_set(RenderSet::Prepare),
             )
             .add_render_graph_node::<ViewNodeRunner<LightingNode>>(Core2d, LightingPass)
             .add_render_graph_edge(Core2d, Node2d::MainPass, LightingPass);

--- a/src/render/lighting/mod.rs
+++ b/src/render/lighting/mod.rs
@@ -1,16 +1,30 @@
 mod node;
 mod pipeline;
+mod prepare;
 
 use bevy::{
     asset::Handle,
-    render::{render_graph::RenderLabel, render_resource::Shader},
+    ecs::component::Component,
+    render::{
+        render_graph::RenderLabel,
+        render_resource::{CachedRenderPipelineId, Shader},
+    },
 };
 
 pub use node::LightingNode;
 pub use pipeline::LightingPipeline;
+pub use prepare::prepare_lighting_pipelines;
 
 pub const LIGHTING_SHADER: Handle<Shader> =
     Handle::weak_from_u128(111120241052143214281687226997564407636);
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, RenderLabel)]
 pub struct LightingPass;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct LightingPipelineKey {
+    pub hdr: bool,
+}
+
+#[derive(Component)]
+pub struct LightingPipelineId(pub CachedRenderPipelineId);

--- a/src/render/lighting/node.rs
+++ b/src/render/lighting/node.rs
@@ -12,7 +12,7 @@ use bevy::utils::smallvec::{smallvec, SmallVec};
 
 use crate::render::extract::{ExtractedAmbientLight2d, ExtractedPointLight2d};
 
-use super::LightingPipeline;
+use super::{LightingPipeline, LightingPipelineId};
 
 const LIGHTING_PASS: &str = "lighting_pass";
 const LIGHTING_BIND_GROUP: &str = "lighting_bind_group";
@@ -25,21 +25,24 @@ impl ViewNode for LightingNode {
         &'static ViewTarget,
         &'static DynamicUniformIndex<ExtractedAmbientLight2d>,
         &'static ViewUniformOffset,
+        &'static LightingPipelineId,
     );
 
     fn run<'w>(
         &self,
         _graph: &mut bevy::render::render_graph::RenderGraphContext,
         render_context: &mut bevy::render::renderer::RenderContext<'w>,
-        (view_target, ambient_index, view_offset): bevy::ecs::query::QueryItem<'w, Self::ViewQuery>,
+        (view_target, ambient_index, view_offset, pipeline_id): bevy::ecs::query::QueryItem<
+            'w,
+            Self::ViewQuery,
+        >,
         world: &'w World,
     ) -> Result<(), bevy::render::render_graph::NodeRunError> {
         let lighting_pipeline = world.resource::<LightingPipeline>();
 
         let pipeline_cache = world.resource::<PipelineCache>();
 
-        let Some(pipeline) = pipeline_cache.get_render_pipeline(lighting_pipeline.pipeline_id)
-        else {
+        let Some(pipeline) = pipeline_cache.get_render_pipeline(pipeline_id.0) else {
             return Ok(());
         };
 

--- a/src/render/lighting/prepare.rs
+++ b/src/render/lighting/prepare.rs
@@ -1,0 +1,35 @@
+use bevy::{
+    ecs::{
+        entity::Entity,
+        query::With,
+        system::{Commands, Query, Res, ResMut},
+    },
+    render::{
+        render_resource::{PipelineCache, SpecializedRenderPipelines},
+        view::ExtractedView,
+    },
+};
+
+use crate::render::extract::ExtractedAmbientLight2d;
+
+use super::{LightingPipeline, LightingPipelineId, LightingPipelineKey};
+
+pub fn prepare_lighting_pipelines(
+    mut commands: Commands,
+    pipeline_cache: Res<PipelineCache>,
+    mut pipelines: ResMut<SpecializedRenderPipelines<LightingPipeline>>,
+    lighting_pipeline: Res<LightingPipeline>,
+    view_targets: Query<(Entity, &ExtractedView), With<ExtractedAmbientLight2d>>,
+) {
+    for (entity, view) in view_targets.iter() {
+        let pipeline_id = pipelines.specialize(
+            &pipeline_cache,
+            &lighting_pipeline,
+            LightingPipelineKey { hdr: view.hdr },
+        );
+
+        commands
+            .entity(entity)
+            .insert(LightingPipelineId(pipeline_id));
+    }
+}


### PR DESCRIPTION
## Summary

As HDR uses a different texture format, we need to set it on a per view basis.

As the pipeline is currently more of a "one and done" construct, we need to make use of a specialized pipeline. It allows us to dynamically create the render pipeline descriptor, giving us a place to hook into if each view has HDR enabled.

On the view node side of things, we need to ensure we're grabbing the specialized pipeline ID from the view entity, as we are no longer constructing a "static" variant of the pipeline.

Closes #10


