### PR TITLE
Fix ambient colour being black not rendering point lights.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed point lights not rendering on a dark ambient color (#24).
+
 ## [0.3.0] - 2024-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+## Changed
 
-- Fixed point lights not rendering on a dark ambient color (#24).
+- Point lights colours are now added to ambient light, instead of multiplied by it (#24).
+
+## Migration guide
+
+- Point light intensity needs to be adjusted to account for changes to ambient light. Generally this means point light intensity values need to be lowered. See the relevant changes to the `dungeon` example.
 
 ## [0.3.0] - 2024-08-05
 

--- a/examples/dungeon.rs
+++ b/examples/dungeon.rs
@@ -72,7 +72,7 @@ fn spawn_candles(mut commands: Commands, spritesheet: Res<CandleSpritesheet>) {
             point_light: PointLight2d {
                 radius: 48.0,
                 color: Color::Srgba(YELLOW),
-                intensity: 25.0,
+                intensity: 2.0,
                 falloff: 4.0,
                 ..default()
             },

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -30,7 +30,7 @@ fn setup(mut commands: Commands) {
         point_light: PointLight2d {
             color: Color::Srgba(Srgba::RED),
             radius: 50.,
-            intensity: 5.0,
+            intensity: 1.0,
             ..default()
         },
         transform: Transform::from_xyz(-50., 25., 0.),
@@ -41,7 +41,7 @@ fn setup(mut commands: Commands) {
         point_light: PointLight2d {
             color: Color::WHITE,
             radius: 50.,
-            intensity: 5.0,
+            intensity: 1.0,
             falloff: 5.0,
             ..default()
         },
@@ -53,7 +53,7 @@ fn setup(mut commands: Commands) {
         point_light: PointLight2d {
             color: Color::Srgba(Srgba::GREEN),
             radius: 75.,
-            intensity: 5.0,
+            intensity: 1.0,
             ..default()
         },
         transform: Transform::from_xyz(-10., -25., 0.),

--- a/src/render/light_map/light_map.wgsl
+++ b/src/render/light_map/light_map.wgsl
@@ -8,7 +8,7 @@
     world_to_ndc
 };
 
-// We're currently only using a single uniform binding for point lights in 
+// We're currently only using a single uniform binding for point lights in
 // WebGL2, which is limited to 4kb in BatchedUniformBuffer, so we need to
 // ensure our point lights can fit in 4kb.
 const MAX_POINT_LIGHTS: u32 = 82u;
@@ -66,7 +66,7 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
         }
     }
 
-    return vec4(ambient_light.color.rgb, 1.0) * vec4(lighting_color, 1.0);
+    return vec4(ambient_light.color.rgb, 1.0) + vec4(lighting_color, 1.0);
 }
 
 fn square(x: f32) -> f32 {
@@ -122,4 +122,3 @@ fn raymarch(ray_origin: vec2<f32>, ray_target: vec2<f32>) -> f32 {
     // ray found occluder
     return 0.0;
 }
-

--- a/src/render/light_map/light_map.wgsl
+++ b/src/render/light_map/light_map.wgsl
@@ -43,7 +43,7 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
         return vec4(ambient_light.color.rgb, 1.0);
     }
 
-    var lighting_color = vec3(1.0);
+    var lighting_color = ambient_light.color.rgb;
 
     // WebGL2 does not support storage buffers (or runtime sized arrays), so we
     // need to use a fixed number of point lights.
@@ -66,7 +66,7 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
         }
     }
 
-    return vec4(ambient_light.color.rgb, 1.0) + vec4(lighting_color, 1.0);
+    return vec4(lighting_color, 1.0);
 }
 
 fn square(x: f32) -> f32 {


### PR DESCRIPTION
## Summary

Uses the ambient light colour as the base for point light rendering instead of multiplying it later with the point light colour. This renders without issues if the ambient colour is black.

Fixes https://github.com/jgayfer/bevy_light_2d/issues/22