### PR TITLE
camera move and zoom for occlusion example

### DIFF
--- a/examples/occlusion.rs
+++ b/examples/occlusion.rs
@@ -1,5 +1,7 @@
 use bevy::{
-    color::palettes::css::{BLUE, YELLOW}, input::mouse::MouseWheel, prelude::*
+    color::palettes::css::{BLUE, YELLOW},
+    input::mouse::MouseWheel,
+    prelude::*,
 };
 use bevy_light_2d::prelude::*;
 
@@ -7,7 +9,10 @@ fn main() {
     App::new()
         .add_plugins((DefaultPlugins, Light2dPlugin))
         .add_systems(Startup, setup)
-        .add_systems(Update, (move_lights, control_camera_movement, control_camera_zoom))
+        .add_systems(
+            Update,
+            (move_lights, control_camera_movement, control_camera_zoom),
+        )
         .run();
 }
 
@@ -128,7 +133,6 @@ fn control_camera_movement(
     mut query_cameras: Query<&mut Transform, With<Camera>>,
     keyboard: Res<ButtonInput<KeyCode>>,
 ) {
-    
     if keyboard.pressed(KeyCode::KeyW) {
         camera_target.y += CAMERA_SPEED;
     }

--- a/examples/occlusion.rs
+++ b/examples/occlusion.rs
@@ -1,6 +1,5 @@
 use bevy::{
-    color::palettes::css::{BLUE, YELLOW},
-    prelude::*,
+    color::palettes::css::{BLUE, YELLOW}, input::mouse::MouseWheel, prelude::*
 };
 use bevy_light_2d::prelude::*;
 
@@ -8,7 +7,7 @@ fn main() {
     App::new()
         .add_plugins((DefaultPlugins, Light2dPlugin))
         .add_systems(Startup, setup)
-        .add_systems(Update, move_lights)
+        .add_systems(Update, (move_lights, control_camera_movement, control_camera_zoom))
         .run();
 }
 
@@ -118,5 +117,63 @@ fn move_lights(
     }
     for mut light_transform in &mut blue_query {
         light_transform.translation.x = time.elapsed_seconds().cos() * 500.
+    }
+}
+
+const CAMERA_SPEED: f32 = 10.0;
+
+fn control_camera_movement(
+    mut camera_current: Local<Vec2>,
+    mut camera_target: Local<Vec2>,
+    mut query_cameras: Query<&mut Transform, With<Camera>>,
+    keyboard: Res<ButtonInput<KeyCode>>,
+) {
+    
+    if keyboard.pressed(KeyCode::KeyW) {
+        camera_target.y += CAMERA_SPEED;
+    }
+    if keyboard.pressed(KeyCode::KeyS) {
+        camera_target.y -= CAMERA_SPEED;
+    }
+    if keyboard.pressed(KeyCode::KeyA) {
+        camera_target.x -= CAMERA_SPEED;
+    }
+    if keyboard.pressed(KeyCode::KeyD) {
+        camera_target.x += CAMERA_SPEED;
+    }
+
+    // Smooth camera.
+    let blend_ratio = 0.2;
+    let movement = *camera_target - *camera_current;
+    *camera_current += movement * blend_ratio;
+
+    // Update all sprite cameras.
+    for mut camera_transform in query_cameras.iter_mut() {
+        camera_transform.translation.x = camera_current.x;
+        camera_transform.translation.y = camera_current.y;
+    }
+}
+
+const MIN_CAMERA_SCALE: f32 = 1.;
+const MAX_CAMERA_SCALE: f32 = 20.;
+
+fn control_camera_zoom(
+    mut cameras: Query<&mut OrthographicProjection, With<Camera>>,
+    time: Res<Time>,
+    mut scroll_event_reader: EventReader<MouseWheel>,
+) {
+    let mut projection_delta = 0.;
+
+    for event in scroll_event_reader.read() {
+        projection_delta += event.y * 3.;
+    }
+
+    if projection_delta == 0. {
+        return;
+    }
+
+    for mut camera in cameras.iter_mut() {
+        camera.scale = (camera.scale - projection_delta * time.delta_seconds())
+            .clamp(MIN_CAMERA_SCALE, MAX_CAMERA_SCALE);
     }
 }


### PR DESCRIPTION
You can now move (using WASD) and zoom (using scroll wheel) in the "occlusion" example. This allows users to test how the lighting works when occluders and light sources are out of view, and how the library handles zoom.

I also used this for my own testing purposes to see how the library handles zooming and movement, and I imagine others would find that helpful as well. The performance costs of the camera move and zoom systems appear negligible.