### PR TITLE
Fix empty buffer size on WebGL2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Crash on WebGL2 when no occluders are present (#36).
+
 ## [0.4.0] - 2024-09-17
 
 ### Changed

--- a/src/render/empty_buffer.rs
+++ b/src/render/empty_buffer.rs
@@ -21,12 +21,19 @@ impl EmptyBuffer {
     }
 
     pub fn fill_buffer(&mut self, render_device: &RenderDevice) {
+        // GpuArrayBuffer uniform buffers are 4096 bytes in size when using WebGl2.
+        //
+        // On platforms that support dynamic storage buffers, we just need something big
+        // enough to "hold" one item.
+        let size = if render_device.limits().max_storage_buffers_per_shader_stage == 0 {
+            4096
+        } else {
+            64
+        };
         if self.buffer.is_none() {
             self.buffer = Some(render_device.create_buffer(&BufferDescriptor {
                 label: "empty-buffer".into(),
-                // This needs to be at least as big as the items we're storing in our
-                // GPUArrayBuffer.
-                size: 64,
+                size,
                 usage: BufferUsages::COPY_DST | BufferUsages::STORAGE | BufferUsages::UNIFORM,
                 mapped_at_creation: false,
             }));


### PR DESCRIPTION
## Summary

On WebGL2 we use a uniform binding that is 4096 bytes in size (due to the
way `GpuArrayBuffer`) works.

In order to not crash on WebGL2, we need to ensure the buffer is big enough
to handle the values we're pretending are there.

Fixes #35 