### PR TITLE
Add constraint to render graph

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -113,7 +113,13 @@ impl Plugin for Light2dPlugin {
             .add_render_graph_node::<ViewNodeRunner<LightMapNode>>(Core2d, LightMapPass)
             .add_render_graph_edges(
                 Core2d,
-                (Node2d::EndMainPass, SdfPass, LightMapPass, LightingPass),
+                (
+                    Node2d::EndMainPass,
+                    SdfPass,
+                    LightMapPass,
+                    LightingPass,
+                    Node2d::Bloom,
+                ),
             );
     }
 


### PR DESCRIPTION
Fixes #34 

I am not sure about #33. 

`NodeUi::UiPass`'s [ordering constraints](https://github.com/bevyengine/bevy/blob/v0.14.2/crates/bevy_ui/src/render/mod.rs#L127) seem nonsensical to me. I am probably not understanding it correctly. But I think that as long as we do your stuff before `Node2d:: EndMainPassPostProcessing`, then this should also fix #33. I'm having trouble actually reproducing the issue though before or after this changeset though.

Not a rendering expert, so this should be scrutinized.

Following the render graph setup in [`custom_post_processing`](https://github.com/bevyengine/bevy/blob/latest/examples/shader/post_processing.rs#L87), it seems that our render graph nodes are constrained to run *after [`Node2d::EndMainPass`](https://docs.rs/bevy/latest/bevy/core_pipeline/core_2d/graph/enum.Node2d.html)*, but otherwise free to run whenever. Might be before or after any of:

`Node2d::Bloom`
`Node2d::Tonemapping`
`Node2d::Fxaa`
`Node2d::Smaa`
`Node2d::Upscaling`
`Node2d::ContrastAdaptiveSharpening`
`Node2d::EndMainPassPostProcessing`

I'm not totally sure this is exactly where the nodes belong, but it *seems* to fix the issue on my end.

I did the following experiments:
```rust
(Node2d::Upscaling, SdfPass, LightMapPass, LightingPass) // Seems to fail 100% of the time
(Node2d::Smaa, SdfPass, LightMapPass, LightingPass, Node2d::Upscaling) // Seems to work all the time
```
So it seems like this definitely needs to run before `Node2d::Upscaling`.