### PR TITLE
Upgrade to Bevy 0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-04-29
+
+### Changed
+
+- Updated Bevy version from `0.15` to `0.16` (#45).
+
 ## [0.5.0] - 2024-12-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,7 @@ bevy = { version = "0.16.0-rc.5", default-features = false, features = [
     "bevy_render",
     "bevy_core_pipeline",
     "bevy_winit",
-    "x11",
-    # TODO: Remove when https://github.com/bevyengine/bevy/issues/16568 is resolved.
-    "bevy_window",
-    # TODO: Remove when https://github.com/bevyengine/bevy/issues/16563 is resolved.
-    "png"
+    "x11"
 ] }
 smallvec = "1.13"
 
@@ -30,9 +26,7 @@ bevy = { version = "0.16.0-rc.5", default-features = false, features = [
     "bevy_winit",
     "bevy_sprite",
     "png",
-    "x11",
-    # TODO: Remove when https://github.com/bevyengine/bevy/issues/16568 is resolved.
-    "bevy_window"
+    "x11"
 ] }
 
 [lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_light_2d"
 version = "0.5.0"
-edition = "2021"
+edition = "2024"
 categories = ["game-engines", "graphics", "rendering"]
 description = "General purpose 2d lighting for the Bevy game engine."
 authors = ["James Gayfer"]
@@ -11,7 +11,7 @@ readme = "README.md"
 exclude = ["assets/*", "static/*"]
 
 [dependencies]
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.16.0-rc.5", default-features = false, features = [
     "bevy_render",
     "bevy_core_pipeline",
     "bevy_winit",
@@ -24,7 +24,7 @@ bevy = { version = "0.15", default-features = false, features = [
 smallvec = "1.13"
 
 [dev-dependencies]
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.16.0-rc.5", default-features = false, features = [
     "bevy_render",
     "bevy_core_pipeline",
     "bevy_winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_light_2d"
-version = "0.5.0"
+version = "0.6.0-rc.1"
 edition = "2024"
 categories = ["game-engines", "graphics", "rendering"]
 description = "General purpose 2d lighting for the Bevy game engine."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_light_2d"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 edition = "2024"
 categories = ["game-engines", "graphics", "rendering"]
 description = "General purpose 2d lighting for the Bevy game engine."
@@ -11,7 +11,7 @@ readme = "README.md"
 exclude = ["assets/*", "static/*"]
 
 [dependencies]
-bevy = { version = "0.16.0-rc.5", default-features = false, features = [
+bevy = { version = "0.16", default-features = false, features = [
     "bevy_render",
     "bevy_core_pipeline",
     "bevy_winit",
@@ -20,7 +20,7 @@ bevy = { version = "0.16.0-rc.5", default-features = false, features = [
 smallvec = "1.13"
 
 [dev-dependencies]
-bevy = { version = "0.16.0-rc.5", default-features = false, features = [
+bevy = { version = "0.16", default-features = false, features = [
     "bevy_render",
     "bevy_core_pipeline",
     "bevy_winit",

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In the [`basic`](https://github.com/jgayfer/bevy_light_2d/blob/main/examples/bas
 # Cargo.toml
 [dependencies]
 bevy = "0.15"
-bevy_light_2d = "0.5"
+bevy_light_2d = "0.6"
 ```
 
 ```rust
@@ -71,6 +71,7 @@ general application over depth of features.
 
 | bevy | bevy_light_2d |
 |------|---------------|
+| 0.16 | 0.6           |
 | 0.15 | 0.5           |
 | 0.14 | 0.2..0.4      |
 | 0.13 | 0.1           |

--- a/examples/dungeon.rs
+++ b/examples/dungeon.rs
@@ -42,7 +42,7 @@ fn setup_camera(mut commands: Commands) {
     projection.scale = 0.25;
     commands.spawn((
         Camera2d,
-        projection,
+        Projection::Orthographic(projection),
         AmbientLight2d {
             brightness: 0.1,
             ..default()

--- a/examples/occlusion.rs
+++ b/examples/occlusion.rs
@@ -145,7 +145,7 @@ const MIN_CAMERA_SCALE: f32 = 1.;
 const MAX_CAMERA_SCALE: f32 = 20.;
 
 fn control_camera_zoom(
-    mut cameras: Query<&mut OrthographicProjection, With<Camera>>,
+    mut projections: Query<&mut Projection, With<Camera>>,
     time: Res<Time>,
     mut scroll_event_reader: EventReader<MouseWheel>,
 ) {
@@ -159,8 +159,10 @@ fn control_camera_zoom(
         return;
     }
 
-    for mut camera in cameras.iter_mut() {
-        camera.scale = (camera.scale - projection_delta * time.delta_secs())
-            .clamp(MIN_CAMERA_SCALE, MAX_CAMERA_SCALE);
+    for projection in projections.iter_mut() {
+        if let Projection::Orthographic(mut camera) = projection.clone() {
+            camera.scale = (camera.scale - projection_delta * time.delta_secs())
+                .clamp(MIN_CAMERA_SCALE, MAX_CAMERA_SCALE);
+        }
     }
 }

--- a/src/light.rs
+++ b/src/light.rs
@@ -7,7 +7,7 @@ use bevy::{
     reflect::Reflect,
     render::{
         sync_world::SyncToRenderWorld,
-        view::{InheritedVisibility, ViewVisibility, Visibility},
+        view::{self, InheritedVisibility, ViewVisibility, Visibility, VisibilityClass},
     },
     transform::components::{GlobalTransform, Transform},
 };
@@ -25,7 +25,8 @@ use bevy::{
 /// [A better point light attenutation function](https://lisyarus.github.io/blog/posts/point-light-attenuation.html#section-the-solution)
 /// by [lisyarus](https://lisyarus.github.io/blog/).
 #[derive(Component, Clone, Reflect)]
-#[require(SyncToRenderWorld, Transform, Visibility)]
+#[require(SyncToRenderWorld, Transform, Visibility, VisibilityClass)]
+#[component(on_add = view::add_visibility_class::<PointLight2d>)]
 pub struct PointLight2d {
     /// The light's color tint.
     pub color: Color,

--- a/src/light.rs
+++ b/src/light.rs
@@ -1,5 +1,4 @@
 //! A module which contains lighting components.
-#![expect(deprecated)]
 
 use bevy::{
     color::Color,

--- a/src/occluder.rs
+++ b/src/occluder.rs
@@ -1,5 +1,4 @@
 //! A module which contains occluder components.
-#![expect(deprecated)]
 
 use bevy::{
     ecs::{bundle::Bundle, component::Component},

--- a/src/occluder.rs
+++ b/src/occluder.rs
@@ -6,7 +6,7 @@ use bevy::{
     math::Vec2,
     render::{
         sync_world::SyncToRenderWorld,
-        view::{InheritedVisibility, ViewVisibility, Visibility},
+        view::{self, InheritedVisibility, ViewVisibility, Visibility, VisibilityClass},
     },
     transform::components::{GlobalTransform, Transform},
 };
@@ -15,7 +15,8 @@ use bevy::{
 ///
 /// This is commonly used as a component within [`LightOcluder2dBundle`].
 #[derive(Default, Component)]
-#[require(SyncToRenderWorld, Transform, Visibility)]
+#[require(SyncToRenderWorld, Transform, Visibility, VisibilityClass)]
+#[component(on_add = view::add_visibility_class::<LightOccluder2d>)]
 pub struct LightOccluder2d {
     /// The shape of the light occluder.
     pub shape: LightOccluder2dShape,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -5,34 +5,33 @@ use bevy::{
     core_pipeline::core_2d::graph::{Core2d, Node2d},
     prelude::*,
     render::{
+        Render, RenderApp, RenderSet,
         extract_component::UniformComponentPlugin,
         gpu_component_array_buffer::GpuComponentArrayBufferPlugin,
         render_graph::{RenderGraphApp, ViewNodeRunner},
         render_resource::SpecializedRenderPipelines,
-        view::{check_visibility, prepare_view_targets, VisibilitySystems},
-        Render, RenderApp, RenderSet,
+        view::prepare_view_targets,
     },
 };
 
 use crate::{
     light::{AmbientLight2d, PointLight2d},
-    occluder::LightOccluder2d,
     render::{
-        empty_buffer::{prepare_empty_buffer, EmptyBuffer},
+        TYPES_SHADER, VIEW_TRANSFORMATIONS_SHADER,
+        empty_buffer::{EmptyBuffer, prepare_empty_buffer},
         extract::{
-            extract_ambient_lights, extract_light_occluders, extract_point_lights,
             ExtractedAmbientLight2d, ExtractedLightOccluder2d, ExtractedPointLight2d,
+            extract_ambient_lights, extract_light_occluders, extract_point_lights,
         },
         light_map::{
-            prepare_light_map_texture, prepare_point_light_count, LightMapNode, LightMapPass,
-            LightMapPipeline, PointLightMetaBuffer, LIGHT_MAP_SHADER,
+            LIGHT_MAP_SHADER, LightMapNode, LightMapPass, LightMapPipeline, PointLightMetaBuffer,
+            prepare_light_map_texture, prepare_point_light_count,
         },
         lighting::{
-            prepare_lighting_pipelines, LightingNode, LightingPass, LightingPipeline,
-            LIGHTING_SHADER,
+            LIGHTING_SHADER, LightingNode, LightingPass, LightingPipeline,
+            prepare_lighting_pipelines,
         },
-        sdf::{prepare_sdf_texture, SdfNode, SdfPass, SdfPipeline, SDF_SHADER},
-        TYPES_SHADER, VIEW_TRANSFORMATIONS_SHADER,
+        sdf::{SDF_SHADER, SdfNode, SdfPass, SdfPipeline, prepare_sdf_texture},
     },
 };
 
@@ -68,15 +67,7 @@ impl Plugin for Light2dPlugin {
             GpuComponentArrayBufferPlugin::<ExtractedLightOccluder2d>::default(),
         ))
         .register_type::<AmbientLight2d>()
-        .register_type::<PointLight2d>()
-        .add_systems(
-            PostUpdate,
-            (
-                check_visibility::<With<PointLight2d>>,
-                check_visibility::<With<LightOccluder2d>>,
-            )
-                .in_set(VisibilitySystems::CheckVisibility),
-        );
+        .register_type::<PointLight2d>();
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;

--- a/src/render/empty_buffer.rs
+++ b/src/render/empty_buffer.rs
@@ -1,5 +1,8 @@
 use bevy::{
-    ecs::system::{Res, ResMut, Resource},
+    ecs::{
+        resource::Resource,
+        system::{Res, ResMut},
+    },
     render::{
         render_resource::{BindingResource, Buffer, BufferDescriptor, BufferUsages},
         renderer::RenderDevice,

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -1,6 +1,6 @@
 use bevy::{
     prelude::*,
-    render::{render_resource::ShaderType, sync_world::RenderEntity, Extract},
+    render::{Extract, render_resource::ShaderType, sync_world::RenderEntity},
 };
 
 use crate::{

--- a/src/render/light_map/mod.rs
+++ b/src/render/light_map/mod.rs
@@ -4,7 +4,8 @@ mod prepare;
 
 use bevy::{
     asset::Handle,
-    ecs::{component::Component, system::Resource},
+    ecs::component::Component,
+    ecs::resource::Resource,
     math::Vec3,
     render::{
         render_graph::RenderLabel,

--- a/src/render/light_map/mod.rs
+++ b/src/render/light_map/mod.rs
@@ -3,9 +3,8 @@ mod pipeline;
 mod prepare;
 
 use bevy::{
-    asset::Handle,
-    ecs::component::Component,
-    ecs::resource::Resource,
+    asset::{Handle, weak_handle},
+    ecs::{component::Component, resource::Resource},
     math::Vec3,
     render::{
         render_graph::RenderLabel,
@@ -18,8 +17,7 @@ pub use node::LightMapNode;
 pub use pipeline::LightMapPipeline;
 pub use prepare::{prepare_light_map_texture, prepare_point_light_count};
 
-pub const LIGHT_MAP_SHADER: Handle<Shader> =
-    Handle::weak_from_u128(320609826414128764415270070474935914193);
+pub const LIGHT_MAP_SHADER: Handle<Shader> = weak_handle!("48777bb3-8a37-4b4d-a4f2-f10ff1ee4360");
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, RenderLabel)]
 pub struct LightMapPass;

--- a/src/render/light_map/node.rs
+++ b/src/render/light_map/node.rs
@@ -9,7 +9,7 @@ use bevy::render::render_resource::{
 };
 use bevy::render::renderer::RenderDevice;
 use bevy::render::view::{ViewUniformOffset, ViewUniforms};
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 use crate::render::empty_buffer::EmptyBuffer;
 use crate::render::extract::{ExtractedAmbientLight2d, ExtractedPointLight2d};

--- a/src/render/light_map/pipeline.rs
+++ b/src/render/light_map/pipeline.rs
@@ -1,5 +1,5 @@
 use bevy::core_pipeline::fullscreen_vertex_shader::fullscreen_shader_vertex_state;
-use bevy::ecs::system::Resource;
+use bevy::ecs::resource::Resource;
 use bevy::ecs::world::{FromWorld, World};
 use bevy::render::render_resource::binding_types::{sampler, texture_2d, uniform_buffer};
 use bevy::render::render_resource::{
@@ -13,7 +13,7 @@ use bevy::render::view::ViewUniform;
 
 use crate::render::extract::{ExtractedAmbientLight2d, ExtractedPointLight2d};
 
-use super::{PointLightMeta, LIGHT_MAP_SHADER};
+use super::{LIGHT_MAP_SHADER, PointLightMeta};
 
 const LIGHT_MAP_BIND_GROUP_LAYOUT: &str = "light_map_group_layout";
 const LIGHT_MAP_PIPELINE: &str = "light_map_pipeline";

--- a/src/render/lighting/mod.rs
+++ b/src/render/lighting/mod.rs
@@ -3,7 +3,7 @@ mod pipeline;
 mod prepare;
 
 use bevy::{
-    asset::Handle,
+    asset::{Handle, weak_handle},
     ecs::component::Component,
     render::{
         render_graph::RenderLabel,
@@ -15,8 +15,7 @@ pub use node::LightingNode;
 pub use pipeline::*;
 pub use prepare::*;
 
-pub const LIGHTING_SHADER: Handle<Shader> =
-    Handle::weak_from_u128(111120241052143214281687226997564407636);
+pub const LIGHTING_SHADER: Handle<Shader> = weak_handle!("22ed6ffe-b47d-4b88-b986-5b0e87b3a240");
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, RenderLabel)]
 pub struct LightingPass;

--- a/src/render/lighting/pipeline.rs
+++ b/src/render/lighting/pipeline.rs
@@ -10,7 +10,7 @@ use bevy::render::render_resource::{
 use bevy::render::renderer::RenderDevice;
 use bevy::render::view::ViewTarget;
 
-use super::{LightingPipelineKey, LIGHTING_SHADER};
+use super::{LIGHTING_SHADER, LightingPipelineKey};
 
 const LIGHTING_PIPELINE: &str = "lighting_pipeline";
 const LIGHTING_BIND_GROUP_LAYOUT: &str = "lighting_bind_group_layout";

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,4 +1,7 @@
-use bevy::{asset::Handle, render::render_resource::Shader};
+use bevy::{
+    asset::{Handle, weak_handle},
+    render::render_resource::Shader,
+};
 
 pub mod empty_buffer;
 pub mod extract;
@@ -6,8 +9,7 @@ pub mod light_map;
 pub mod lighting;
 pub mod sdf;
 
-pub const TYPES_SHADER: Handle<Shader> =
-    Handle::weak_from_u128(134542958402584092759402858489640143033);
+pub const TYPES_SHADER: Handle<Shader> = weak_handle!("606bf813-c0cc-40c8-9fd6-ffcb6a5d66d8");
 
 pub const VIEW_TRANSFORMATIONS_SHADER: Handle<Shader> =
-    Handle::weak_from_u128(134542958402584092759402858489640143039);
+    weak_handle!("16d31d1e-b859-4c6b-90ed-a66b93e0b86f");

--- a/src/render/sdf/mod.rs
+++ b/src/render/sdf/mod.rs
@@ -3,7 +3,7 @@ mod pipeline;
 mod prepare;
 
 use bevy::{
-    asset::Handle,
+    asset::{Handle, weak_handle},
     ecs::component::Component,
     render::{render_graph::RenderLabel, render_resource::Shader, texture::CachedTexture},
 };
@@ -12,8 +12,7 @@ pub use node::SdfNode;
 pub use pipeline::SdfPipeline;
 pub use prepare::prepare_sdf_texture;
 
-pub const SDF_SHADER: Handle<Shader> =
-    Handle::weak_from_u128(231804371047309214783091483091843019281);
+pub const SDF_SHADER: Handle<Shader> = weak_handle!("16251728-6dd9-481e-95a7-7c2e0ff8d920");
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, RenderLabel)]
 pub struct SdfPass;

--- a/src/render/sdf/node.rs
+++ b/src/render/sdf/node.rs
@@ -8,13 +8,13 @@ use bevy::render::render_resource::{
 };
 use bevy::render::renderer::RenderDevice;
 use bevy::render::view::{ViewUniformOffset, ViewUniforms};
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 use crate::render::empty_buffer::EmptyBuffer;
 use crate::render::extract::ExtractedLightOccluder2d;
 
-use super::pipeline::SdfPipeline;
 use super::SdfTexture;
+use super::pipeline::SdfPipeline;
 
 const SDF_PASS: &str = "sdf_pass";
 const SDF_BIND_GROUP: &str = "sdf_bind_group";


### PR DESCRIPTION
## Summary

Published to crates.io as [`0.6.0-rc.1`](https://crates.io/crates/bevy_light_2d/0.6.0-rc.1).