### PR TITLE
Fix occluders not despawning correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lighting is no longer processed by default; the `Light2d` marker component
   must be added to the `Camera2d` (#49).
 
+### Fixed
+
+- Fixed occluders not despawning correctly (#47).
+- Improved WebGL2 performance (#47).
+
 ### Migration guide
 
 - Add a `Light2d` marker component to cameras that should process lighting

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -31,7 +31,10 @@ use crate::{
             LIGHTING_SHADER, LightingNode, LightingPass, LightingPipeline,
             prepare_lighting_pipelines,
         },
-        sdf::{SDF_SHADER, SdfNode, SdfPass, SdfPipeline, prepare_sdf_texture},
+        sdf::{
+            OccluderMetaBuffer, SDF_SHADER, SdfNode, SdfPass, SdfPipeline, prepare_occluder_meta,
+            prepare_sdf_texture,
+        },
     },
 };
 
@@ -76,6 +79,7 @@ impl Plugin for Light2dPlugin {
         render_app
             .init_resource::<SpecializedRenderPipelines<LightingPipeline>>()
             .init_resource::<PointLightMetaBuffer>()
+            .init_resource::<OccluderMetaBuffer>()
             .init_resource::<EmptyBuffer>()
             .add_systems(
                 ExtractSchedule,
@@ -90,6 +94,7 @@ impl Plugin for Light2dPlugin {
                 (
                     prepare_lighting_pipelines.in_set(RenderSet::Prepare),
                     prepare_point_light_count.in_set(RenderSet::Prepare),
+                    prepare_occluder_meta.in_set(RenderSet::Prepare),
                     prepare_empty_buffer.in_set(RenderSet::Prepare),
                     prepare_sdf_texture
                         .after(prepare_view_targets)

--- a/src/render/sdf/mod.rs
+++ b/src/render/sdf/mod.rs
@@ -4,12 +4,18 @@ mod prepare;
 
 use bevy::{
     asset::{Handle, weak_handle},
-    ecs::component::Component,
-    render::{render_graph::RenderLabel, render_resource::Shader, texture::CachedTexture},
+    ecs::{component::Component, resource::Resource},
+    math::Vec3,
+    render::{
+        render_graph::RenderLabel,
+        render_resource::{Shader, ShaderType, UniformBuffer},
+        texture::CachedTexture,
+    },
 };
 
 pub use node::SdfNode;
 pub use pipeline::SdfPipeline;
+pub use prepare::prepare_occluder_meta;
 pub use prepare::prepare_sdf_texture;
 
 pub const SDF_SHADER: Handle<Shader> = weak_handle!("16251728-6dd9-481e-95a7-7c2e0ff8d920");
@@ -20,4 +26,24 @@ pub struct SdfPass;
 #[derive(Component)]
 pub struct SdfTexture {
     pub sdf: CachedTexture,
+}
+#[derive(Resource, Default)]
+pub struct OccluderMetaBuffer {
+    pub buffer: UniformBuffer<OccluderMeta>,
+}
+
+#[derive(Default, ShaderType)]
+pub struct OccluderMeta {
+    pub count: u32,
+    // WebGL2 structs must be 16 byte aligned.
+    _padding: Vec3,
+}
+
+impl OccluderMeta {
+    pub fn new(count: u32) -> Self {
+        Self {
+            count,
+            _padding: Vec3::ZERO,
+        }
+    }
 }

--- a/src/render/sdf/pipeline.rs
+++ b/src/render/sdf/pipeline.rs
@@ -10,6 +10,7 @@ use bevy::render::renderer::RenderDevice;
 use bevy::render::view::ViewUniform;
 
 use crate::render::extract::ExtractedLightOccluder2d;
+use crate::render::light_map::PointLightMeta;
 
 use super::SDF_SHADER;
 
@@ -34,6 +35,7 @@ impl FromWorld for SdfPipeline {
                 (
                     uniform_buffer::<ViewUniform>(true),
                     GpuArrayBuffer::<ExtractedLightOccluder2d>::binding_layout(render_device),
+                    uniform_buffer::<PointLightMeta>(false),
                 ),
             ),
         );

--- a/src/render/sdf/prepare.rs
+++ b/src/render/sdf/prepare.rs
@@ -5,13 +5,15 @@ use bevy::{
     },
     render::{
         render_resource::{TextureDescriptor, TextureDimension, TextureFormat, TextureUsages},
-        renderer::RenderDevice,
+        renderer::{RenderDevice, RenderQueue},
         texture::TextureCache,
         view::ViewTarget,
     },
 };
 
-use super::SdfTexture;
+use crate::render::extract::ExtractedLightOccluder2d;
+
+use super::{OccluderMeta, OccluderMetaBuffer, SdfTexture};
 
 const SDF_TEXTURE: &str = "sdf_texture";
 
@@ -40,4 +42,17 @@ pub fn prepare_sdf_texture(
             .entity(entity)
             .insert(SdfTexture { sdf: sdf_texture });
     }
+}
+
+pub fn prepare_occluder_meta(
+    render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
+    occluders: Query<&ExtractedLightOccluder2d>,
+    mut occluder_meta_buffer: ResMut<OccluderMetaBuffer>,
+) {
+    let meta = OccluderMeta::new(occluders.iter().len() as u32);
+    occluder_meta_buffer.buffer.set(meta);
+    occluder_meta_buffer
+        .buffer
+        .write_buffer(&render_device, &render_queue);
 }

--- a/src/render/sdf/sdf.wgsl
+++ b/src/render/sdf/sdf.wgsl
@@ -1,6 +1,6 @@
 #import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
 #import bevy_render::view::View
-#import bevy_light_2d::types::LightOccluder2d
+#import bevy_light_2d::types::{LightOccluder2d, OccluderMeta};
 #import bevy_light_2d::view_transformations::{frag_coord_to_ndc, ndc_to_world};
 
 // We're currently only using a single uniform binding for occluders in
@@ -23,19 +23,22 @@ var<uniform> view: View;
     var<uniform> occluders: array<LightOccluder2d, MAX_OCCLUDERS>;
 #endif
 
+@group(0) @binding(2)
+var<uniform> occluder_meta: OccluderMeta;
+
 @fragment
 fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let pos = ndc_to_world(frag_coord_to_ndc(in.position.xy));
 
-    var sdf = occluder_sd(pos, occluders[0]);
-
     // WebGL2 does not support storage buffers (or runtime sized arrays), so we
     // need to use a fixed number of occluders.
 #if AVAILABLE_STORAGE_BUFFER_BINDINGS >= 6
-    let occluder_count = arrayLength(&occluders);
+    let occluder_count = occluder_meta.count;
 #else
-    let occluder_count = MAX_OCCLUDERS;
+    let occluder_count = min(MAX_OCCLUDERS, occluder_meta.count);
 #endif
+
+    var sdf = occluder_sd(pos, occluders[0]);
 
     for (var i = 1u; i < occluder_count; i++) {
         sdf = min(sdf, occluder_sd(pos, occluders[i]));

--- a/src/render/sdf/sdf.wgsl
+++ b/src/render/sdf/sdf.wgsl
@@ -38,6 +38,11 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let occluder_count = min(MAX_OCCLUDERS, occluder_meta.count);
 #endif
 
+    // If there aren't any occluders, use the max value for the texture.
+    if (occluder_count == 0) {
+        return vec4(255.0, 0.0, 0.0, 1.0);
+    }
+
     var sdf = occluder_sd(pos, occluders[0]);
 
     for (var i = 1u; i < occluder_count; i++) {

--- a/src/render/types.wgsl
+++ b/src/render/types.wgsl
@@ -23,3 +23,9 @@ struct PointLightMeta {
     // WebGL2 structs must be 16 byte aligned.
     _padding: vec3<u32>
 }
+
+struct OccluderMeta {
+    count: u32,
+    // WebGL2 structs must be 16 byte aligned.
+    _padding: vec3<u32>
+}


### PR DESCRIPTION
## Summary

If there aren't any occluders, we can default to the max texture value (which maps to distance).

This change fixes https://github.com/jgayfer/bevy_light_2d/issues/43, as we're no longer attempting to act on junk data.

### Why junk data?

The way `GPUArrayBuffer` works, there may be allocated space that does not
hold useful data.

This is fine if you never despawn an occluder, but as soon as we do, we
end up with "junk" data that might still exist in the buffer. If we use
`arrayLength` to determine the number of occluders in play, we're not
going to get the right answer.

Instead, we can bind the number of occluders separately, and use that
for an accurate count.