### PR TITLE
Require marker component for processing lighting effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `Light2d` "marker" component to indicate which cameras should process
   lighting effects (#49).
+- Added "minimap" example to showcase camera with lighting disabled (#49).
 - Add reflection for Component and Default on `PointLight2D` and `AmbientLight` (#50).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `Light2d` "marker" component to indicate which cameras should process
+  lighting effects (#49).
 - Add reflection for Component and Default on `PointLight2D` and `AmbientLight` (#50).
+
+### Changed
+
+- Lighting is no longer processed by default; the `Light2d` marker component
+  must be added to the `Camera2d` (#49).
+
+### Migration guide
+
+- Add a `Light2d` marker component to cameras that should process lighting
+  effects.
+- Remove `AmbientLight2d` components from cameras. Instead, include them as a
+  field on the camera's `Light2d` marker component.
 
 ## [0.6.0] - 2025-04-29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,7 @@ path = "examples/dungeon.rs"
 [[example]]
 name = "occlusion"
 path = "examples/occlusion.rs"
+
+[[example]]
+name = "minimap"
+path = "examples/minimap.rs"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2d);
+    commands.spawn((Camera2d, Light2d::default()));
 
     commands.spawn(PointLight2d {
         intensity: 3.0,

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -9,7 +9,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2d);
+    commands.spawn((Camera2d, Light2d::default()));
 
     commands.spawn(PointLight2d {
         intensity: 3.0,

--- a/examples/dungeon.rs
+++ b/examples/dungeon.rs
@@ -43,9 +43,11 @@ fn setup_camera(mut commands: Commands) {
     commands.spawn((
         Camera2d,
         Projection::Orthographic(projection),
-        AmbientLight2d {
-            brightness: 0.1,
-            ..default()
+        Light2d {
+            ambient_light: AmbientLight2d {
+                brightness: 0.1,
+                ..default()
+            },
         },
     ));
 }

--- a/examples/minimap.rs
+++ b/examples/minimap.rs
@@ -1,0 +1,43 @@
+use bevy::{prelude::*, render::camera::Viewport};
+use bevy_light_2d::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, Light2dPlugin))
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    // Main camera
+    commands.spawn((Camera2d, Light2d::default()));
+
+    // Minimap camera, without a Light2d marker (disabling the lighting pipeline)
+    commands.spawn((
+        Camera2d,
+        Camera {
+            order: 1,
+            clear_color: ClearColorConfig::Default,
+            viewport: Some(Viewport {
+                physical_position: UVec2::new(10, 10),
+                physical_size: UVec2::new(200, 200),
+                ..default()
+            }),
+            ..default()
+        },
+        Transform::from_xyz(0.0, 0.0, 0.0).with_scale(Vec3::splat(3.0)),
+        Light2d::default(),
+    ));
+
+    // The "player"
+    commands.spawn((
+        Sprite {
+            custom_size: Some(Vec2::new(25.0, 30.0)),
+            ..Default::default()
+        },
+        PointLight2d {
+            radius: 375.0,
+            ..default()
+        },
+    ));
+}

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -11,9 +11,11 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.spawn((
         Camera2d,
-        AmbientLight2d {
-            brightness: 0.1,
-            ..default()
+        Light2d {
+            ambient_light: AmbientLight2d {
+                brightness: 0.1,
+                ..default()
+            },
         },
     ));
 

--- a/examples/occlusion.rs
+++ b/examples/occlusion.rs
@@ -23,7 +23,7 @@ struct YellowLight;
 struct BlueLight;
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2d);
+    commands.spawn((Camera2d, Light2d::default()));
 
     commands.spawn((
         PointLight2d {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod render;
 
 /// A module which exports commonly used dependencies.
 pub mod prelude {
-    pub use crate::light::{AmbientLight2d, PointLight2d, PointLight2dBundle};
+    pub use crate::light::{AmbientLight2d, Light2d, PointLight2d, PointLight2dBundle};
     pub use crate::occluder::{LightOccluder2d, LightOccluder2dBundle, LightOccluder2dShape};
     pub use crate::plugin::Light2dPlugin;
 }

--- a/src/light.rs
+++ b/src/light.rs
@@ -12,6 +12,15 @@ use bevy::{
     transform::components::{GlobalTransform, Transform},
 };
 
+/// A "marker" component to be used with a `Camera2d`.
+///
+/// 2D lighting effects will only run for cameras that have this component.
+#[derive(Component, Default)]
+pub struct Light2d {
+    /// The ambight light to apply to the scene.
+    pub ambient_light: AmbientLight2d,
+}
+
 /// A light that provides illumination in all directions.
 ///
 /// This is commonly used as a component within [`PointLight2dBundle`].

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -4,7 +4,7 @@ use bevy::{
 };
 
 use crate::{
-    light::{AmbientLight2d, PointLight2d},
+    light::{Light2d, PointLight2d},
     occluder::{LightOccluder2d, LightOccluder2dShape},
 };
 
@@ -89,24 +89,13 @@ pub fn extract_light_occluders(
 
 pub fn extract_ambient_lights(
     mut commands: Commands,
-    ambient_light_query: Extract<Query<(&RenderEntity, &AmbientLight2d)>>,
-    camera_query: Extract<Query<&RenderEntity, (With<Camera2d>, Without<AmbientLight2d>)>>,
+    light_2d_query: Extract<Query<(&RenderEntity, &Light2d)>>,
 ) {
-    for (render_entity, ambient_light) in &ambient_light_query {
+    for (render_entity, light_2d) in &light_2d_query {
         commands
             .entity(render_entity.id())
             .insert(ExtractedAmbientLight2d {
-                color: ambient_light.color.to_linear() * ambient_light.brightness,
-            });
-    }
-
-    // Our lighting pass only runs on views with an ambient light component,
-    // so let's add a no-op ambient light to any 2d cameras don't have one.
-    for render_entity in &camera_query {
-        commands
-            .entity(render_entity.id())
-            .insert(ExtractedAmbientLight2d {
-                color: Color::WHITE.into(),
+                color: light_2d.ambient_light.color.to_linear() * light_2d.ambient_light.brightness,
             });
     }
 }


### PR DESCRIPTION
## Summary

Originally I wanted to make this library as easy to use as possible. This
meant that all `Camera2d` components would process lighting out of the
box.

However, this has lead to a few instances of "the principle of least
surprise" being broken.

For example, a UI only camera is something that currently isn't possible
with the existing library.

An option I considered was an opt-out component, but I don't super feel
this aligns with "the Bevy way". I view an opt-in as something less
likely to cause problems / surprises down the road.