### PR TITLE
Fix stale render data when lights or occluders are hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed lights and occluders not being removed when `ViewVisibility` is false (#63).
+
 ## [0.9.0] - 2026-03-04
 
 ### Added

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -45,6 +45,9 @@ pub fn extract_spot_lights(
 ) {
     for (render_entity, spot_light, global_transform, view_visibility) in &q {
         if !view_visibility.get() {
+            commands
+                .entity(render_entity.id())
+                .remove::<ExtractedSpotLight2d>();
             continue;
         }
         let direction_radians = spot_light.direction.to_radians();
@@ -92,6 +95,9 @@ pub fn extract_point_lights(
 ) {
     for (render_entity, point_light, global_transform, view_visibility) in &point_light_query {
         if !view_visibility.get() {
+            commands
+                .entity(render_entity.id())
+                .remove::<ExtractedPointLight2d>();
             continue;
         }
         commands
@@ -121,6 +127,9 @@ pub fn extract_light_occluders(
     for (render_entity, light_occluder, global_transform, view_visibility) in &light_occluders_query
     {
         if !view_visibility.get() {
+            commands
+                .entity(render_entity.id())
+                .remove::<ExtractedLightOccluder2d>();
             continue;
         }
 


### PR DESCRIPTION
## Summary

- Explicitly remove `ExtractedPointLight2d` / `ExtractedSpotLight2d` / `ExtractedLightOccluder2d` from the render entity when `ViewVisibility` is false, instead of just skipping extraction
- Prevents lights and occluders from continuing to render with stale position and parameters after `Visibility::Hidden` is set
- Consistent with how Bevy handles this in `bevy_pbr` for `ExtractedDirectionalLight`

Fixes #62

## Test plan

- Spawn a `PointLight2d` as a child of a moving entity
- Toggle `Visibility` between `Inherited` and `Hidden` over time
- Verify the light disappears immediately when hidden and reappears at the correct position when made visible again
- Repeat for `SpotLight2d` and `LightOccluder2d`