### PR TITLE
Fix lights and occluders being culled by their entity's AABB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed lights and occluders not being removed when `ViewVisibility` is false (#63).
+- Fixed lights and occluders not being removed when hidden (#63).
+- Fixed lights and occluders not rendering when attached to an entity with a
+  `Sprite`, once that sprite left the camera frustum. Visibility is now based on
+  `InheritedVisibility` (whether the entity is hidden) rather than
+  `ViewVisibility` (whether it survived frustum culling), so a sprite's bounds no
+  longer determine whether its light is rendered (#26).
 
 ## [0.9.0] - 2026-03-04
 

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -39,12 +39,12 @@ pub fn extract_spot_lights(
             &RenderEntity,
             &SpotLight2d,
             &GlobalTransform,
-            &ViewVisibility,
+            &InheritedVisibility,
         )>,
     >,
 ) {
-    for (render_entity, spot_light, global_transform, view_visibility) in &q {
-        if !view_visibility.get() {
+    for (render_entity, spot_light, global_transform, inherited_visibility) in &q {
+        if !inherited_visibility.get() {
             commands
                 .entity(render_entity.id())
                 .remove::<ExtractedSpotLight2d>();
@@ -89,12 +89,12 @@ pub fn extract_point_lights(
             &RenderEntity,
             &PointLight2d,
             &GlobalTransform,
-            &ViewVisibility,
+            &InheritedVisibility,
         )>,
     >,
 ) {
-    for (render_entity, point_light, global_transform, view_visibility) in &point_light_query {
-        if !view_visibility.get() {
+    for (render_entity, point_light, global_transform, inherited_visibility) in &point_light_query {
+        if !inherited_visibility.get() {
             commands
                 .entity(render_entity.id())
                 .remove::<ExtractedPointLight2d>();
@@ -120,13 +120,14 @@ pub fn extract_light_occluders(
             &RenderEntity,
             &LightOccluder2d,
             &GlobalTransform,
-            &ViewVisibility,
+            &InheritedVisibility,
         )>,
     >,
 ) {
-    for (render_entity, light_occluder, global_transform, view_visibility) in &light_occluders_query
+    for (render_entity, light_occluder, global_transform, inherited_visibility) in
+        &light_occluders_query
     {
-        if !view_visibility.get() {
+        if !inherited_visibility.get() {
             commands
                 .entity(render_entity.id())
                 .remove::<ExtractedLightOccluder2d>();


### PR DESCRIPTION
## Summary

The intent here was always to stop lights and occluders from showing up if they're set to be hidden.

However, in using `ViewVisibility`, we were actually hooking into whether Bevy had frustum culled the entity.

For basic lights, this wasn't an issue in itself, as they have no `AABB`. But when attached to a `Sprite` for example, which does have an `AABB`, the entity was no longer extracted once the `Sprite` itself was culled, even if the radius of the light extended beyond the `Sprite`.

By using `InheritedVisibility`, we're instead simply checking if the entity is hidden, ignoring any type of culling.

Fixes #26.

### Example

```rust
use bevy::prelude::*;
use bevy_light_2d::prelude::*;

fn main() {
    App::new()
        .add_plugins((DefaultPlugins, Light2dPlugin))
        .add_systems(Startup, setup)
        .add_systems(Update, pan_camera)
        .run();
}

fn setup(mut commands: Commands) {
    commands.spawn((
        Camera2d,
        Light2d {
            ambient_light: AmbientLight2d {
                brightness: 0.02,
                ..default()
            },
        },
    ));

    // A light attached to a sprite, with a radius far larger than the sprite.
    commands.spawn((
        Sprite::from_color(Color::srgb(0.8, 0.1, 0.1), Vec2::splat(32.0)),
        PointLight2d {
            radius: 300.0,
            intensity: 10.0,
            ..default()
        },
    ));
}

// Pan right until the sprite leaves the frustum, but the light radius doesn't.
fn pan_camera(camera: Single<&mut Transform, With<Camera2d>>, time: Res<Time>) {
    camera.into_inner().translation.x += 100.0 * time.delta_secs();
}
```


