### PR TITLE
Cull point and spot lights not visible by any camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated Bevy version from `0.18` to `0.19` (#64).
+- Cull point and spot lights not visible by any camera (#67).
 
 ### Fixed
 

--- a/examples/issue_26.rs
+++ b/examples/issue_26.rs
@@ -1,0 +1,96 @@
+//! Repro for https://github.com/jgayfer/bevy_light_2d/issues/26
+//!
+//! A `PointLight2d` is attached directly to a sprite entity, with a light
+//! radius much larger than the sprite. The camera pans right until the sprite
+//! leaves the frustum.
+//!
+//! Before the fix, extraction filtered on `ViewVisibility`, so the light was
+//! dropped the moment the *sprite's* `Aabb` left the frustum, even though the
+//! light's radius still reached well into view. Watch for the glow on the left
+//! edge popping out at once.
+//!
+//! After the fix, the glow fades out smoothly as the light's own radius clears
+//! the edge.
+
+use bevy::prelude::*;
+use bevy_light_2d::prelude::*;
+
+const LIGHT_RADIUS: f32 = 300.0;
+const CAMERA_SPEED: f32 = 100.0;
+const CAMERA_RESET_X: f32 = 1200.0;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, Light2dPlugin))
+        .add_systems(Startup, setup)
+        .add_systems(Update, pan_camera)
+        .run();
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn((
+        Camera2d,
+        Light2d {
+            ambient_light: AmbientLight2d {
+                brightness: 0.02,
+                ..default()
+            },
+        },
+    ));
+
+    // Something for the light to fall on.
+    commands.spawn((
+        Sprite {
+            color: Color::srgb(0.7, 0.7, 0.75),
+            custom_size: Some(Vec2::new(4000.0, 1000.0)),
+            ..default()
+        },
+        Transform::from_xyz(1000.0, 0.0, -1.0),
+    ));
+
+    // The light rides on the sprite entity. This is what issue #26 is about.
+    commands.spawn((
+        Sprite {
+            image: asset_server.load("candle.png"),
+            ..default()
+        },
+        PointLight2d {
+            radius: LIGHT_RADIUS,
+            intensity: 3.0,
+            falloff: 4.0,
+            color: Color::srgb(1.0, 0.85, 0.4),
+            ..default()
+        },
+        Transform::from_xyz(0.0, 0.0, 0.0),
+    ));
+}
+
+fn pan_camera(
+    time: Res<Time>,
+    mut last_zone: Local<Option<&'static str>>,
+    camera: Single<&mut Transform, With<Camera2d>>,
+    window: Single<&Window>,
+) {
+    let mut transform = camera.into_inner();
+    transform.translation.x += CAMERA_SPEED * time.delta_secs();
+    if transform.translation.x > CAMERA_RESET_X {
+        transform.translation.x = 0.0;
+    }
+
+    // The sprite sits at x = 0, so the camera's x is also the distance between
+    // them. Report which side of each boundary we're on.
+    let half_width = window.width() / 2.0;
+    let sprite_gone = transform.translation.x > half_width + 32.0;
+    let light_gone = transform.translation.x > half_width + LIGHT_RADIUS;
+
+    let zone = match (sprite_gone, light_gone) {
+        (false, _) => "sprite on screen -> lit",
+        (true, false) => "sprite off screen, light radius still reaches -> MUST STILL BE LIT",
+        (true, true) => "light radius cleared the edge -> dark is correct",
+    };
+
+    if *last_zone != Some(zone) {
+        *last_zone = Some(zone);
+        println!("camera x {:>7.1}  |  {zone}", transform.translation.x);
+    }
+}

--- a/examples/min26.rs
+++ b/examples/min26.rs
@@ -1,0 +1,37 @@
+use bevy::prelude::*;
+use bevy_light_2d::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, Light2dPlugin))
+        .add_systems(Startup, setup)
+        .add_systems(Update, pan_camera)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn((
+        Camera2d,
+        Light2d {
+            ambient_light: AmbientLight2d {
+                brightness: 0.02,
+                ..default()
+            },
+        },
+    ));
+
+    // A light attached to a sprite, with a radius far larger than the sprite.
+    commands.spawn((
+        Sprite::from_color(Color::srgb(0.8, 0.1, 0.1), Vec2::splat(32.0)),
+        PointLight2d {
+            radius: 300.0,
+            intensity: 10.0,
+            ..default()
+        },
+    ));
+}
+
+// Pan right until the sprite leaves the frustum, but the light radius doesn't.
+fn pan_camera(camera: Single<&mut Transform, With<Camera2d>>, time: Res<Time>) {
+    camera.into_inner().translation.x += 100.0 * time.delta_secs();
+}

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -1,4 +1,5 @@
 use bevy::{
+    camera::primitives::Frustum,
     prelude::*,
     render::{Extract, render_resource::ShaderType, sync_world::RenderEntity},
 };
@@ -42,9 +43,17 @@ pub fn extract_spot_lights(
             &InheritedVisibility,
         )>,
     >,
+    frustum_query: Extract<Query<&Frustum, (With<Camera2d>, With<Light2d>)>>,
 ) {
     for (render_entity, spot_light, global_transform, inherited_visibility) in &q {
-        if !inherited_visibility.get() {
+        let center = global_transform.translation().xy();
+
+        let visible = inherited_visibility.get()
+            && frustum_query
+                .iter()
+                .any(|frustum| circle_intersects_frustum(frustum, center, spot_light.radius));
+
+        if !visible {
             commands
                 .entity(render_entity.id())
                 .remove::<ExtractedSpotLight2d>();
@@ -92,9 +101,16 @@ pub fn extract_point_lights(
             &InheritedVisibility,
         )>,
     >,
+    frustum_query: Extract<Query<&Frustum, (With<Camera2d>, With<Light2d>)>>,
 ) {
     for (render_entity, point_light, global_transform, inherited_visibility) in &point_light_query {
-        if !inherited_visibility.get() {
+        let center = global_transform.translation().xy();
+        let visible = inherited_visibility.get()
+            && frustum_query
+                .iter()
+                .any(|frustum| circle_intersects_frustum(frustum, center, point_light.radius));
+
+        if !visible {
             commands
                 .entity(render_entity.id())
                 .remove::<ExtractedPointLight2d>();
@@ -104,13 +120,27 @@ pub fn extract_point_lights(
             .entity(render_entity.id())
             .insert(ExtractedPointLight2d {
                 color: point_light.color.to_linear(),
-                transform: global_transform.translation().xy(),
+                transform: center,
                 radius: point_light.radius,
                 intensity: point_light.intensity,
                 falloff: point_light.falloff,
                 cast_shadows: if point_light.cast_shadows { 1 } else { 0 },
             });
     }
+}
+
+fn circle_intersects_frustum(frustum: &Frustum, center: Vec2, radius: f32) -> bool {
+    // Lights reach the GPU as 2d positions and the light map isn't depth tested, so z is dropped
+    // here too, along with the near and far half-spaces that bound the camera in depth. Culling on
+    // depth would hide lights that still light the scene.
+    let center = center.extend(0.0).extend(1.0);
+    let [left, right, top, bottom, ..] = frustum.half_spaces;
+
+    [left, right, top, bottom].iter().all(|edge| {
+        // Distance from the light's centre to this edge of the screen, positive towards the
+        // inside. Adding the radius asks whether any part of the light reaches in.
+        edge.normal_d().dot(center) + radius > 0.0
+    })
 }
 
 pub fn extract_light_occluders(


### PR DESCRIPTION
## Summary

We've been sending all point and spot lights to the GPU whether they are visible or not. For large scenes, this is a cripping performance bottleneck.

By checking if a light intersects any frustum prior to sending it to the GPU, we can significantly reduce the performance overhead.

See the [`benchmark`](examples/benchmark.rs) example to try it out.


